### PR TITLE
Fix parsing with tag reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2023-01-25
+
+### Added
+
+- A release can now include the tag reference (when provided) that can be found at the bottom of the changelog.
+
+### Changed
+
+- Applied property promotion to the models.
+
+### Fixed
+
+- Parsing a changelog with tag references resulted in an error. See [#3](https://github.com/vdhicts/keepachangelog-parser/issues/3), thanks to @bergo for reporting.
+
 ## [1.1.0] - 2022-02-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ $version = $release->getVersion();
 // Get the release date, will be null when not released or a date isn't provided
 $data = $release->getReleasedAt();
 
+// Get the tag reference, usually something like https://github.com/vdhicts/keepachangelog-parser/compare/v0.0.1...v1.0.0
+$tagReference = $release->getTagReference();
+
 // Get a specific section of the release
 $added = $release->getSection(Section::ADDED);
 

--- a/src/Models/Changelog.php
+++ b/src/Models/Changelog.php
@@ -6,13 +6,8 @@ use Illuminate\Support\Collection;
 
 class Changelog
 {
-    private Collection $releases;
-    private array $description;
-
-    public function __construct(Collection $releases, array $description = [])
+    public function __construct(private Collection $releases, private array $description = [])
     {
-        $this->releases = $releases;
-        $this->description = $description;
     }
 
     public function getReleases(): Collection

--- a/src/Models/Release.php
+++ b/src/Models/Release.php
@@ -9,14 +9,13 @@ class Release
 {
     public const UNRELEASED = 'Unreleased';
 
-    private string $version;
-    private ?DateTimeInterface $releasedAt;
     private Collection $sections;
 
-    public function __construct(string $version, DateTimeInterface $releasedAt = null)
-    {
-        $this->version = $version;
-        $this->releasedAt = $releasedAt;
+    public function __construct(
+        private string $version,
+        private ?DateTimeInterface $releasedAt = null,
+        private ?string $tagReference = null
+    ) {
         $this->sections = collect();
     }
 
@@ -28,6 +27,16 @@ class Release
     public function getReleasedAt(): ?DateTimeInterface
     {
         return $this->releasedAt;
+    }
+
+    public function getTagReference(): ?string
+    {
+        return $this->tagReference;
+    }
+
+    public function setTagReference(?string $tagReference): void
+    {
+        $this->tagReference = $tagReference;
     }
 
     public function getSections(): Collection

--- a/src/Models/Section.php
+++ b/src/Models/Section.php
@@ -11,13 +11,8 @@ class Section
     public const REMOVED = 'Removed';
     public const SECURITY = 'Security';
 
-    private string $type;
-    private array $entries;
-
-    public function __construct(string $type, array $entries)
+    public function __construct(private string $type, private array $entries)
     {
-        $this->type = $type;
-        $this->entries = $entries;
     }
 
     public function getType(): string

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -29,6 +29,7 @@ class ParserTest extends TestCase
         $this->assertCount(13, $this->changelog->getReleases());
         $this->assertInstanceOf(Release::class, $this->changelog->getLatestRelease());
         $this->assertInstanceOf(Release::class, $this->changelog->getUnreleased());
+        $this->assertNotNull($this->changelog->getLatestRelease()->getTagReference());
     }
 
     public function testUnreleased()
@@ -41,6 +42,7 @@ class ParserTest extends TestCase
         $this->assertNull($unreleased->getReleasedAt());
         $this->assertCount(0, $unreleased->getSections());
         $this->assertNull($unreleased->getSection(Section::ADDED));
+        $this->assertNotNull($this->changelog->getLatestRelease()->getTagReference());
     }
 
     public function testRelease()
@@ -56,6 +58,7 @@ class ParserTest extends TestCase
         $this->assertCount(3, $release->getSections());
         $this->assertInstanceOf(Section::class, $release->getSection(Section::ADDED));
         $this->assertNull($release->getSection(Section::DEPRECATED));
+        $this->assertNotNull($release->getTagReference());
     }
 
     public function testSection()

--- a/tests/resources/ExampleChangelog.md
+++ b/tests/resources/ExampleChangelog.md
@@ -135,3 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - README now contains answers to common questions about CHANGELOGs
 - Good examples and basic guidelines, including proper date formatting.
 - Counter-examples: "What makes unicorns cry?"
+
+[unreleased]: https://github.com/vdhicts/keepachangelog-parser/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/vdhicts/keepachangelog-parser/compare/v0.0.1...v1.0.0
+[0.0.1]: https://github.com/vdhicts/keepachangelog-parser/releases/tag/v0.0.1


### PR DESCRIPTION
Closes #3 

# Changes

### Added

- A release can now include the tag reference (when provided) that can be found at the bottom of the changelog.

### Changed

- Applied property promotion to the models.

### Fixed

- Parsing a changelog with tag references resulted in an error. See [#3](https://github.com/vdhicts/keepachangelog-parser/issues/3), thanks to @bergo for reporting.

# Checks

- [x] The changelog is updated (when applicable)
