### PR TITLE
add HTML support for entries

### DIFF
--- a/src/Models/Entry.php
+++ b/src/Models/Entry.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Vdhicts\KeepAChangelog\Models;
+
+class Entry
+{
+    public function __construct(
+        private readonly string $html,
+        private readonly string $plain,
+    ) {}
+
+    public function toString(): string
+    {
+        return $this->plain;
+    }
+
+    public function toHtml(): string
+    {
+        return $this->html;
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Carbon;
 use League\CommonMark\CommonMarkConverter;
 use Symfony\Component\DomCrawler\Crawler;
 use Vdhicts\KeepAChangelog\Models\Changelog;
+use Vdhicts\KeepAChangelog\Models\Entry;
 use Vdhicts\KeepAChangelog\Models\Release;
 use Vdhicts\KeepAChangelog\Models\Section;
 
@@ -44,8 +45,15 @@ class Parser
 
         return new Section(
             $parsedSection->text(),
-            $this->getNodesText($lines)
+            $this->parseEntries($lines)
         );
+    }
+
+    private function parseEntries(Crawler $lines)
+    {
+        return $lines->each(function ($node) {
+            return new Entry($node->html(), $node->text());
+        });
     }
 
     public function parse(string $content): Changelog

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -5,6 +5,7 @@ namespace Vdhicts\KeepAChangelog\Tests\Unit;
 use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 use Vdhicts\KeepAChangelog\Models\Changelog;
+use Vdhicts\KeepAChangelog\Models\Entry;
 use Vdhicts\KeepAChangelog\Models\Release;
 use Vdhicts\KeepAChangelog\Models\Section;
 use Vdhicts\KeepAChangelog\Parser;
@@ -71,5 +72,21 @@ class ParserTest extends TestCase
         $this->assertSame(Section::ADDED, $section->getType());
         $this->assertIsArray($section->getEntries());
         $this->assertCount(23, $section->getEntries());
+    }
+
+    public function testEntry()
+    {
+        $entries = $this
+            ->changelog
+            ->getLatestRelease()
+            ->getSection(Section::ADDED)
+            ->getEntries();
+
+        $entry = $entries[0];
+
+        $this->assertInstanceOf(Entry::class, $entry);
+        $this->assertSame('New visual identity by <a href="https://github.com/tylerfortune8">@tylerfortune8</a>.', $entry->toHtml());
+        $this->assertSame('New visual identity by @tylerfortune8.', $entry->toString());
+        $this->assertSame('New visual identity by @tylerfortune8.', (string) $entry);
     }
 }


### PR DESCRIPTION
# Changes

Entry is now a value-object holding both the plain-text & HTML representation of the changelog line.
This probably will be considered a breaking change requiring a major version bump, but I'll leave that up to you.

# Checks

- [ ] The changelog is updated (when applicable)
