### PR TITLE
Add Laravel 12 and PHP 8.4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.1', '8.2', '8.3', '8.4' ]
+        php-versions: [ '8.2', '8.3', '8.4' ]
 
     name: PHP ${{ matrix.php-versions }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [ '8.1', '8.2', '8.3' ]
+        php-versions: [ '8.1', '8.2', '8.3', '8.4' ]
 
     name: PHP ${{ matrix.php-versions }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2025-02-24
+
+### Added
+
+- Add support for Laravel 11.
+
+### Changed
+
+- Move Pint to dev dependencies. Thanks to @julesjanssen.
+
+### Removed
+
+- Remove Laravel 9 and 10 support as they no longer receives any updates.
+
 ## [2.2.0] - 2024-03-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Add support for Laravel 11.
+- Add support for Laravel 12.
+- Add support for PHP 8.4.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 
 - Remove Laravel 9 and 10 support as they no longer receives any updates.
+- Remove support for PHP 8.1.
 
 ## [2.2.0] - 2024-03-17
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "illuminate/support": "^9.0|^10.0|^11.0",
+        "illuminate/support": "^11.0|^12.0",
         "league/commonmark": "^2.2",
         "symfony/css-selector": "^6.0|^7.0",
         "symfony/dom-crawler": "^6.0|^7.0"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "illuminate/support": "^11.0|^12.0",
         "league/commonmark": "^2.2",
         "symfony/css-selector": "^6.0|^7.0",
@@ -25,7 +25,7 @@
     "require-dev": {
         "laravel/pint": "^1.20",
         "phpstan/phpstan": "^1.2",
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
     <report>
       <html outputDirectory="build/coverage"/>
     </report>
@@ -14,4 +11,9 @@
     </testsuite>
   </testsuites>
   <logging/>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/pint.json
+++ b/pint.json
@@ -2,6 +2,7 @@
     "preset": "laravel",
     "rules": {
         "array_indentation": false,
-        "phpdoc_align": false
+        "phpdoc_align": false,
+        "new_with_parentheses": false
     }
 }

--- a/src/Models/Changelog.php
+++ b/src/Models/Changelog.php
@@ -6,9 +6,7 @@ use Illuminate\Support\Collection;
 
 class Changelog
 {
-    public function __construct(private readonly Collection $releases, private readonly array $description = [])
-    {
-    }
+    public function __construct(private readonly Collection $releases, private readonly array $description = []) {}
 
     public function getReleases(): Collection
     {

--- a/src/Models/Entry.php
+++ b/src/Models/Entry.php
@@ -7,8 +7,7 @@ class Entry
     public function __construct(
         private readonly string $html,
         private readonly string $plain,
-    ) {
-    }
+    ) {}
 
     public function toString(): string
     {

--- a/src/Models/Section.php
+++ b/src/Models/Section.php
@@ -16,9 +16,7 @@ class Section
 
     public const SECURITY = 'Security';
 
-    public function __construct(private readonly string $type, private readonly array $entries)
-    {
-    }
+    public function __construct(private readonly string $type, private readonly array $entries) {}
 
     public function getType(): string
     {

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -22,7 +22,7 @@ class ParserTest extends TestCase
         $this->changelog = $parser->parse($changelogContent);
     }
 
-    public function testChangelog()
+    public function test_changelog()
     {
         $this->assertTrue($this->changelog->hasReleases());
         $this->assertIsArray($this->changelog->getDescription());
@@ -33,7 +33,7 @@ class ParserTest extends TestCase
         $this->assertNotNull($this->changelog->getLatestRelease()->getTagReference());
     }
 
-    public function testUnreleased()
+    public function test_unreleased()
     {
         $unreleased = $this
             ->changelog
@@ -46,7 +46,7 @@ class ParserTest extends TestCase
         $this->assertNotNull($this->changelog->getLatestRelease()->getTagReference());
     }
 
-    public function testRelease()
+    public function test_release()
     {
         $release = $this
             ->changelog
@@ -62,7 +62,7 @@ class ParserTest extends TestCase
         $this->assertNotNull($release->getTagReference());
     }
 
-    public function testSection()
+    public function test_section()
     {
         $section = $this
             ->changelog
@@ -74,7 +74,7 @@ class ParserTest extends TestCase
         $this->assertCount(23, $section->getEntries());
     }
 
-    public function testEntry()
+    public function test_entry()
     {
         $entries = $this
             ->changelog

--- a/tests/Unit/ParserTestDateTimeFormatTest.php
+++ b/tests/Unit/ParserTestDateTimeFormatTest.php
@@ -19,7 +19,7 @@ class ParserTestDateTimeFormatTest extends TestCase
         $this->changelog = $parser->parse($changelogContent);
     }
 
-    public function testRelease()
+    public function test_release()
     {
         $release = $this
             ->changelog


### PR DESCRIPTION
# Changes

### Added

- Add support for Laravel 12.
- Add support for PHP 8.4.

### Removed

- Remove Laravel 9 and 10 support as they no longer receive any updates.
- Remove support for PHP 8.1.

# Checks

- [x] The changelog is updated (when applicable)
